### PR TITLE
Avoid creating multiple update branches

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -37,7 +37,6 @@ jobs:
         committer: CodeforIATI bot <57559326+codeforIATIbot@users.noreply.github.com>
         author: CodeforIATI bot <57559326+codeforIATIbot@users.noreply.github.com>
         branch: update
-        branch-suffix: timestamp
         delete-branch: true
         title: Automated update
         body: This update was sent from [this GitHub Action build](https://github.com/datasets/dac-and-crs-code-lists/actions/runs/${{ github.run_id }}).


### PR DESCRIPTION
Whenever there are updates, these should always be pushed to the `update` branch rather than adding the timestamp as a suffix to the branch name. This avoids creating multiple identical PRs.